### PR TITLE
Add TPC-H into CI perf testing

### DIFF
--- a/benchs/tpch/run.sh
+++ b/benchs/tpch/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -eu
+set -o pipefail
+
+TAR_VER=$(tarantool -v | grep -e "Tarantool" |  grep -oP '\s\K\S*')
+numaopts="numactl --membind=1 --cpunodebind=1 --physcpubind=6,7,8,9,10,11"
+base_dir=$(pwd)
+
+cd /opt/tpch
+make create_SQL_db
+
+killall tarantool 2>/dev/null || true
+sync && echo "sync passed" || echo "sync failed with error" $?
+echo 3 > /proc/sys/vm/drop_caches
+
+make bench-sqlite NUMAOPTS=$numaopts
+make create_TNT_db
+
+killall tarantool 2>/dev/null || true
+sync && echo "sync passed" || echo "sync failed with error" $?
+echo 3 > /proc/sys/vm/drop_caches
+
+make bench-tnt NUMAOPTS=$numaopts
+make report
+sed "/-2/d" bench-tnt.csv | sed "s/;/:/" | sed "s/-1/0/" | tee tpc.h_result.txt
+
+echo ${TAR_VER} | tee tpc.h_t_version.txt
+cp -f tpc.h_t_version.txt $base_dir
+cp -f tpc.h_result.txt $base_dir
+cp -f bench-sqlite.csv $base_dir
+cp -f bench-tnt.csv $base_dir
+
+echo "Tarantool TAG:"
+cat tpc.h_t_version.txt
+echo "Overall result SQL:"
+echo "==================="
+cat bench-sqlite.csv
+echo " "
+echo "Overall result TNT:"
+echo "==================="
+cat tpc.h_result.txt
+echo " "
+echo "Publish data to bench database"
+/opt/bench-run/benchs/publication/publish.py

--- a/dockerfiles/ubuntu_benchs
+++ b/dockerfiles/ubuntu_benchs
@@ -71,6 +71,10 @@ RUN luarocks install \
     https://raw.githubusercontent.com/tarantool/gperftools/master/rockspecs/gperftools-scm-1.rockspec \
     --local >build.log 2>&1 || ( cat build.log && false )
 
+# TPC-H
+RUN git clone https://github.com/tarantool/tpch.git /opt/tpch
+RUN apt-get install -y -f sqlite3
+
 # adding python dependency
 RUN pip install requests
 

--- a/dockerfiles/ubuntu_tnt_tpch
+++ b/dockerfiles/ubuntu_tnt_tpch
@@ -1,0 +1,17 @@
+ARG image_from
+FROM ${image_from}
+
+COPY . /opt/tarantool
+WORKDIR /opt/tarantool
+
+# patching Tarantool sources for using with TPC-H
+RUN patch -p1 < /opt/tpch/patches/v1-0001-Restore-partial-date-time-support-in-Tarantool-SQ.patch
+RUN patch -p1 < /opt/tpch/patches/v1-0002-Restore-date-datetime-tests.patch
+
+RUN git submodule update --recursive --init --force
+RUN ( cmake . -DENABLE_DIST=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo >build.log 2>&1 \
+    && make -j >>build.log 2>&1 && make install >>build.log 2>&1 ) || \
+    ( cat build.log && false )
+
+# benchmarks runners
+RUN git clone https://github.com/tarantool/bench-run.git /opt/bench-run

--- a/targets.mk
+++ b/targets.mk
@@ -11,6 +11,8 @@ DOCKERFILE_BUILD=docker build --network=host
 #   images with always changed Tarantool sources and its
 #   depends benchmarks like 'cbench', image need to be
 #   removed after each testing to save the disk space
+# - perf_tmp_tpch/ubuntu-bionic:perf_<commit_SHA>
+#   image with patched Tarantool sources for TPC-H bench.
 # #########################################################
 prepare:
 	docker login -u ${CI_REGISTRY_USER} -p ${CI_REGISTRY_PASSWORD} \
@@ -23,9 +25,15 @@ prepare:
 	${DOCKERFILE_BUILD} --build-arg image_from=${IMAGE_PERF} \
 		-t ${IMAGE_PERF_BUILT} --no-cache -f bench-run/dockerfiles/ubuntu_tnt .
 	docker push ${IMAGE_PERF_BUILT}
+	# build Tarantool patched for TPC-H bench
+	${DOCKERFILE_BUILD} --build-arg image_from=${IMAGE_PERF} \
+		-t ${IMAGE_PERF_TPCH_BUILT} --no-cache -f bench-run/dockerfiles/ubuntu_tnt_tpch .
+	docker push ${IMAGE_PERF_TPCH_BUILT}
 
 # #####################################################
 # Remove temporary performance image from the test host
 # #####################################################
 cleanup:
 	docker rmi --force ${IMAGE_PERF_BUILT}
+	docker rmi --force ${IMAGE_PERF_TPCH_BUILT}
+


### PR DESCRIPTION
- adding docker image with patched Tarantool
  for running TPC-H bench
- adding TPC-H bench into CI perf testing