### PR TITLE
Fix msgpack-c sources

### DIFF
--- a/dockerfiles/ubuntu_benchs
+++ b/dockerfiles/ubuntu_benchs
@@ -26,7 +26,8 @@ RUN ( cmake . >build.log 2>&1 && make -j >>build.log 2>&1 && \
     make install >>build.log 2>&1 ) || ( cat build.log && false )
 
 # msgpack-c
-RUN git clone https://github.com/msgpack/msgpack-c.git /opt/msgpack-c
+RUN curl -L https://github.com/msgpack/msgpack-c/releases/download/cpp-3.3.0/msgpack-3.3.0.tar.gz \
+        | tar xvz -C /opt/msgpack-c --strip-components=1 >/dev/null
 WORKDIR /opt/msgpack-c
 RUN ( cmake . >build.log 2>&1 && make -j >>build.log 2>&1 && \
     make install >>build.log 2>&1 ) || ( cat build.log && false )


### PR DESCRIPTION
After msgpack-c sources updated:
```
  commit 7d5324f2945aa2b9186cddda5a28c903272b205e
  Merge: 6e7deb80 61f8780d
  Author: Takatoshi Kondo <redboltz@gmail.com>
  Date:   Mon Jun 8 09:26:18 2020 +0900

    Merge pull request #878 from ygj6/master

    remove files in master for separating C and C++ libraries

  commit 61f8780d599153f51fc0882569f19e1c163dd5a4
  Author: yuangongji <yuangongji@foxmail.com>
  Date:   Fri Jun 5 17:49:01 2020 +0800

    remove files in master for separating C and C++ libraries
```

Latest workable commit found:
  6e7deb809120881634b3ca895e66b2a946084f34 (tag: cpp-3.3.0)

Set to use cpp-3.3.0 tag for msgpack-c repository.

Fixes tarantool/tarantool#5077