### PR TITLE
tpch: remove tests patching (as it failed once)

### DIFF
--- a/dockerfiles/ubuntu_tnt_tpch
+++ b/dockerfiles/ubuntu_tnt_tpch
@@ -7,8 +7,6 @@ WORKDIR /opt/tarantool
 # patching Tarantool sources for using with TPC-H
 RUN patch -p1 < /opt/tpch/patches/v1-0001-Restore-partial-date-time-support-in-Tarantool-SQ.patch \
     || ( echo "ERROR: Patch not ready for Tarantool sources !" && exit 1)
-RUN patch -p1 < /opt/tpch/patches/v1-0002-Restore-date-datetime-tests.patch \
-    || ( echo "ERROR: Patch not ready for Tarantool sources !" && exit 1)
 
 RUN git submodule update --recursive --init --force
 RUN ( cmake . -DENABLE_DIST=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo >build.log 2>&1 \


### PR DESCRIPTION
To run TPC-H benchmarks we needed specially crafted patches, which were enabling datetime / timestamp support in SQL. We could not commit those patches to the Tarantool master and need to reapply each time we run TPC-H because they are half baked, and not ready for product. But were good enough for running TPC-H benchmarks for monitoring SQL performance improvements.

Unfortunately patchset has started to fail during application to master. Closer investigation showed that tests were failing, not Tarantool kernel patch. So as a temporary fix we disable test patch, but still leave kernel one.