### PR TITLE
Updated TPC-H patch for master

### DIFF
--- a/dockerfiles/ubuntu_tnt_tpch
+++ b/dockerfiles/ubuntu_tnt_tpch
@@ -5,7 +5,7 @@ COPY . /opt/tarantool
 WORKDIR /opt/tarantool
 
 # patching Tarantool sources for using with TPC-H
-RUN patch -p1 < /opt/tpch/patches/v1-0001-Restore-partial-date-time-support-in-Tarantool-SQ.patch \
+RUN patch -p1 < /opt/tpch/patches/0001-sql-add-datetime-support-for-TPCH.patch \
     || ( echo "ERROR: Patch not ready for Tarantool sources !" && exit 1)
 
 RUN git submodule update --recursive --init --force


### PR DESCRIPTION
Since recently we have modified some SQL code base, thus
TPC-H datetime patch should be updated accordingly.

https://github.com/tarantool/tpch/pull/9 changed name of patch
used, thus we need to update docker instructions accordingly.