### PR TITLE
tpch: fix datetime patching

### DIFF
--- a/dockerfiles/ubuntu_tnt_tpch
+++ b/dockerfiles/ubuntu_tnt_tpch
@@ -5,7 +5,7 @@ COPY . /opt/tarantool
 WORKDIR /opt/tarantool
 
 # patching Tarantool sources for using with TPC-H
-RUN patch -p1 < /opt/tpch/patches/0001-sql-add-datetime-support-for-TPCH.patch \
+RUN patch -p1 < /opt/tpch/patches/*.patch \
     || ( echo "ERROR: Patch not ready for Tarantool sources !" && exit 1)
 
 RUN git submodule update --recursive --init --force


### PR DESCRIPTION
Datetime is not fully enable in sql now. There is a patch, which have to fixed it.
It was rebased and pushed in other naming.